### PR TITLE
added data logging

### DIFF
--- a/backend/app/routes/interactions.py
+++ b/backend/app/routes/interactions.py
@@ -6,7 +6,7 @@ Phase 1 endpoint(s) for swipe event capture from Discover.
 
 from __future__ import annotations
 
-from typing import Optional, Literal
+from typing import Any, Dict, Optional, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -428,6 +428,201 @@ async def get_my_saved_listings_for_group(
         return {"status": "success", "saved_listing_ids": ids}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch saved listings: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Data logging endpoints (analytics / AI training)
+# All four are best-effort: failures are returned as 500 but callers should
+# fire-and-forget these. They write to new tables and never touch existing ones.
+# ---------------------------------------------------------------------------
+
+class SwipeContextEventCreate(BaseModel):
+    listing_id: str
+    action: Literal["like", "pass", "super_like", "group_save"]
+    session_id: str = Field(..., min_length=1, max_length=128)
+    active_filters_snapshot: Optional[Dict[str, Any]] = None
+    device_context: Optional[Dict[str, Any]] = None
+
+
+class ListingViewEventCreate(BaseModel):
+    listing_id: str
+    surface: Literal["discover_card", "listing_detail", "matches_card"]
+    session_id: str = Field(..., min_length=1, max_length=128)
+    view_duration_ms: Optional[int] = Field(default=None, ge=0)
+    expanded: bool = False
+    photos_viewed_count: int = Field(default=0, ge=0)
+
+
+class PageViewEventCreate(BaseModel):
+    page: Literal[
+        "discover", "matches", "listing_detail", "preferences",
+        "account", "groups", "roommates", "onboarding"
+    ]
+    session_id: str = Field(..., min_length=1, max_length=128)
+    duration_ms: Optional[int] = Field(default=None, ge=0)
+    referrer_page: Optional[str] = Field(default=None, max_length=100)
+
+
+class SearchQueryEventCreate(BaseModel):
+    session_id: str = Field(..., min_length=1, max_length=128)
+    filter_snapshot: Dict[str, Any]
+    results_returned: int = Field(default=0, ge=0)
+    offset: int = Field(default=0, ge=0)
+
+
+@router.post("/swipe-context")
+async def create_swipe_context_event(
+    payload: SwipeContextEventCreate,
+    token: str = Depends(require_user_token),
+):
+    """
+    Persist filter + device context alongside a swipe.
+
+    Companion to POST /swipes — writes to swipe_context_events without
+    touching the existing swipe_interactions table. Join the two tables on
+    (actor_user_id, listing_id, session_id) to get the full swipe picture.
+    """
+    supabase = get_admin_client()
+    user_id = _resolve_current_user_id(token)
+
+    try:
+        insert_data = {
+            "actor_user_id": user_id,
+            "listing_id": payload.listing_id,
+            "session_id": payload.session_id,
+            "action": payload.action,
+            "active_filters_snapshot": payload.active_filters_snapshot,
+            "device_context": payload.device_context,
+        }
+        created = supabase.table("swipe_context_events").insert(insert_data).execute()
+        if not created.data:
+            raise HTTPException(status_code=500, detail="Swipe context event was not persisted")
+        return {"status": "success", "event_id": created.data[0]["event_id"]}
+    except HTTPException:
+        raise
+    except Exception as e:
+        err = str(e).lower()
+        if "swipe_context_events" in err and "does not exist" in err:
+            raise HTTPException(
+                status_code=503,
+                detail="swipe_context_events table not found. Run migration 012.",
+            )
+        raise HTTPException(status_code=500, detail=f"Failed to store swipe context: {e}")
+
+
+@router.post("/listing-views")
+async def create_listing_view_event(
+    payload: ListingViewEventCreate,
+    token: str = Depends(require_user_token),
+):
+    """
+    Persist a listing view duration event.
+
+    Fire on card mount (discover stack, matches grid) and on listing detail
+    page unmount. Best-effort — callers should not block on this response.
+    """
+    supabase = get_admin_client()
+    user_id = _resolve_current_user_id(token)
+
+    try:
+        insert_data = {
+            "user_id": user_id,
+            "listing_id": payload.listing_id,
+            "surface": payload.surface,
+            "session_id": payload.session_id,
+            "view_duration_ms": payload.view_duration_ms,
+            "expanded": payload.expanded,
+            "photos_viewed_count": payload.photos_viewed_count,
+        }
+        created = supabase.table("listing_view_events").insert(insert_data).execute()
+        if not created.data:
+            raise HTTPException(status_code=500, detail="Listing view event was not persisted")
+        return {"status": "success", "event_id": created.data[0]["event_id"]}
+    except HTTPException:
+        raise
+    except Exception as e:
+        err = str(e).lower()
+        if "listing_view_events" in err and "does not exist" in err:
+            raise HTTPException(
+                status_code=503,
+                detail="listing_view_events table not found. Run migration 014.",
+            )
+        raise HTTPException(status_code=500, detail=f"Failed to store listing view event: {e}")
+
+
+@router.post("/page-views")
+async def create_page_view_event(
+    payload: PageViewEventCreate,
+    token: str = Depends(require_user_token),
+):
+    """
+    Persist a page view event for funnel analytics.
+
+    Fire on page component mount; send duration_ms on unmount via keepalive fetch.
+    """
+    supabase = get_admin_client()
+    user_id = _resolve_current_user_id(token)
+
+    try:
+        insert_data = {
+            "user_id": user_id,
+            "page": payload.page,
+            "session_id": payload.session_id,
+            "duration_ms": payload.duration_ms,
+            "referrer_page": payload.referrer_page,
+        }
+        created = supabase.table("page_view_events").insert(insert_data).execute()
+        if not created.data:
+            raise HTTPException(status_code=500, detail="Page view event was not persisted")
+        return {"status": "success", "event_id": created.data[0]["event_id"]}
+    except HTTPException:
+        raise
+    except Exception as e:
+        err = str(e).lower()
+        if "page_view_events" in err and "does not exist" in err:
+            raise HTTPException(
+                status_code=503,
+                detail="page_view_events table not found. Run migration 016.",
+            )
+        raise HTTPException(status_code=500, detail=f"Failed to store page view event: {e}")
+
+
+@router.post("/search-queries")
+async def create_search_query_event(
+    payload: SearchQueryEventCreate,
+    token: str = Depends(require_user_token),
+):
+    """
+    Persist a search/filter event for demand intelligence.
+
+    Fire each time the discover feed calls /api/recommendations, capturing
+    the full filter state and how many results were returned.
+    """
+    supabase = get_admin_client()
+    user_id = _resolve_current_user_id(token)
+
+    try:
+        insert_data = {
+            "user_id": user_id,
+            "session_id": payload.session_id,
+            "filter_snapshot": payload.filter_snapshot,
+            "results_returned": payload.results_returned,
+            "offset": payload.offset,
+        }
+        created = supabase.table("search_query_events").insert(insert_data).execute()
+        if not created.data:
+            raise HTTPException(status_code=500, detail="Search query event was not persisted")
+        return {"status": "success", "event_id": created.data[0]["event_id"]}
+    except HTTPException:
+        raise
+    except Exception as e:
+        err = str(e).lower()
+        if "search_query_events" in err and "does not exist" in err:
+            raise HTTPException(
+                status_code=503,
+                detail="search_query_events table not found. Run migration 018.",
+            )
+        raise HTTPException(status_code=500, detail=f"Failed to store search query event: {e}")
 
 
 @router.get("/behavior/health")

--- a/backend/migrations/012_swipe_context_events.sql
+++ b/backend/migrations/012_swipe_context_events.sql
@@ -1,0 +1,36 @@
+-- Migration: Create swipe_context_events table
+-- Purpose: Companion to swipe_interactions. Captures filter state + device context
+--          at swipe time without altering the existing prod table.
+--          Join to swipe_interactions on (actor_user_id, listing_id, session_id).
+-- Date: 2026-04-03
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.swipe_context_events (
+    event_id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    actor_user_id           uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    listing_id              uuid        NOT NULL REFERENCES public.listings(id) ON DELETE CASCADE,
+    session_id              text        NOT NULL,
+    action                  text        NOT NULL CHECK (action IN ('like', 'pass', 'super_like', 'group_save')),
+    active_filters_snapshot jsonb       NULL,
+    device_context          jsonb       NULL,
+    created_at              timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index to join back to swipe_interactions
+CREATE INDEX IF NOT EXISTS idx_swipe_context_events_user_session
+    ON public.swipe_context_events (actor_user_id, session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_swipe_context_events_listing
+    ON public.swipe_context_events (listing_id, created_at DESC);
+
+COMMENT ON TABLE public.swipe_context_events IS
+    'Companion to swipe_interactions. Stores filter + device context at swipe time. Join on (actor_user_id, listing_id, session_id).';
+
+COMMENT ON COLUMN public.swipe_context_events.active_filters_snapshot IS
+    'Full copy of the preference/filter object active at the time of the swipe (budget, city, bedrooms, etc.).';
+
+COMMENT ON COLUMN public.swipe_context_events.device_context IS
+    'Browser-collected device context: device_type, os, browser, screen_width, screen_height, connection_type.';
+
+COMMIT;

--- a/backend/migrations/013_swipe_context_events_privileges.sql
+++ b/backend/migrations/013_swipe_context_events_privileges.sql
@@ -1,0 +1,25 @@
+-- Migration: RLS policies for swipe_context_events
+-- Date: 2026-04-03
+
+BEGIN;
+
+GRANT USAGE ON SCHEMA public TO authenticated, service_role;
+GRANT SELECT, INSERT ON TABLE public.swipe_context_events TO authenticated, service_role;
+
+ALTER TABLE public.swipe_context_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "swipe_context_events_insert_own" ON public.swipe_context_events;
+CREATE POLICY "swipe_context_events_insert_own"
+    ON public.swipe_context_events
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (actor_user_id = auth.uid());
+
+DROP POLICY IF EXISTS "swipe_context_events_select_own" ON public.swipe_context_events;
+CREATE POLICY "swipe_context_events_select_own"
+    ON public.swipe_context_events
+    FOR SELECT
+    TO authenticated
+    USING (actor_user_id = auth.uid());
+
+COMMIT;

--- a/backend/migrations/014_listing_view_events.sql
+++ b/backend/migrations/014_listing_view_events.sql
@@ -1,0 +1,45 @@
+-- Migration: Create listing_view_events table
+-- Purpose: Track how long users look at listings before acting.
+--          Key signal for AI training and realtor engagement analytics.
+-- Surfaces: discover_card (swipe stack), listing_detail (full page), matches_card (matches grid)
+-- Date: 2026-04-03
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.listing_view_events (
+    event_id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id             uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    listing_id          uuid        NOT NULL REFERENCES public.listings(id) ON DELETE CASCADE,
+    surface             text        NOT NULL CHECK (surface IN ('discover_card', 'listing_detail', 'matches_card')),
+    session_id          text        NOT NULL,
+    view_duration_ms    integer     NULL CHECK (view_duration_ms IS NULL OR view_duration_ms >= 0),
+    expanded            boolean     NOT NULL DEFAULT false,
+    photos_viewed_count integer     NOT NULL DEFAULT 0 CHECK (photos_viewed_count >= 0),
+    created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_listing_view_events_user_created_at
+    ON public.listing_view_events (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_listing_view_events_listing_created_at
+    ON public.listing_view_events (listing_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_listing_view_events_surface
+    ON public.listing_view_events (surface, created_at DESC);
+
+COMMENT ON TABLE public.listing_view_events IS
+    'Records how long a user views a listing card or detail page before acting.';
+
+COMMENT ON COLUMN public.listing_view_events.surface IS
+    'Where the view occurred: discover_card (swipe stack), listing_detail (full page), matches_card (matches grid).';
+
+COMMENT ON COLUMN public.listing_view_events.expanded IS
+    'True if the user tapped to open the detail modal or navigated to the full listing page during this view.';
+
+COMMENT ON COLUMN public.listing_view_events.photos_viewed_count IS
+    'Number of distinct photo advances observed during the view (auto-advance + manual swipe).';
+
+COMMENT ON COLUMN public.listing_view_events.view_duration_ms IS
+    'Null if the user navigated away without triggering a clean unmount (tab close, crash).';
+
+COMMIT;

--- a/backend/migrations/015_listing_view_events_privileges.sql
+++ b/backend/migrations/015_listing_view_events_privileges.sql
@@ -1,0 +1,25 @@
+-- Migration: RLS policies for listing_view_events
+-- Date: 2026-04-03
+
+BEGIN;
+
+GRANT USAGE ON SCHEMA public TO authenticated, service_role;
+GRANT SELECT, INSERT ON TABLE public.listing_view_events TO authenticated, service_role;
+
+ALTER TABLE public.listing_view_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "listing_view_events_insert_own" ON public.listing_view_events;
+CREATE POLICY "listing_view_events_insert_own"
+    ON public.listing_view_events
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "listing_view_events_select_own" ON public.listing_view_events;
+CREATE POLICY "listing_view_events_select_own"
+    ON public.listing_view_events
+    FOR SELECT
+    TO authenticated
+    USING (user_id = auth.uid());
+
+COMMIT;

--- a/backend/migrations/016_page_view_events.sql
+++ b/backend/migrations/016_page_view_events.sql
@@ -1,0 +1,38 @@
+-- Migration: Create page_view_events table
+-- Purpose: Funnel analytics — track which pages users visit and for how long.
+--          Reveals drop-off points in the signup → preferences → discover → match funnel.
+-- Date: 2026-04-03
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.page_view_events (
+    event_id      uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       uuid        NULL REFERENCES public.users(id) ON DELETE SET NULL,
+    page          text        NOT NULL CHECK (page IN (
+                                  'discover', 'matches', 'listing_detail', 'preferences',
+                                  'account', 'groups', 'roommates', 'onboarding'
+                              )),
+    session_id    text        NOT NULL,
+    duration_ms   integer     NULL CHECK (duration_ms IS NULL OR duration_ms >= 0),
+    referrer_page text        NULL,
+    created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Partial index: only index authenticated views
+CREATE INDEX IF NOT EXISTS idx_page_view_events_user_created_at
+    ON public.page_view_events (user_id, created_at DESC)
+    WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_page_view_events_page_created_at
+    ON public.page_view_events (page, created_at DESC);
+
+COMMENT ON TABLE public.page_view_events IS
+    'Page-level funnel analytics. Nullable user_id supports future anonymous tracking.';
+
+COMMENT ON COLUMN public.page_view_events.duration_ms IS
+    'Null if the user navigated away without triggering a clean React unmount (e.g. tab close).';
+
+COMMENT ON COLUMN public.page_view_events.referrer_page IS
+    'The page the user came from within the app, if known.';
+
+COMMIT;

--- a/backend/migrations/017_page_view_events_privileges.sql
+++ b/backend/migrations/017_page_view_events_privileges.sql
@@ -1,0 +1,25 @@
+-- Migration: RLS policies for page_view_events
+-- Date: 2026-04-03
+
+BEGIN;
+
+GRANT USAGE ON SCHEMA public TO authenticated, service_role;
+GRANT SELECT, INSERT ON TABLE public.page_view_events TO authenticated, service_role;
+
+ALTER TABLE public.page_view_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "page_view_events_insert_own" ON public.page_view_events;
+CREATE POLICY "page_view_events_insert_own"
+    ON public.page_view_events
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (user_id = auth.uid() OR user_id IS NULL);
+
+DROP POLICY IF EXISTS "page_view_events_select_own" ON public.page_view_events;
+CREATE POLICY "page_view_events_select_own"
+    ON public.page_view_events
+    FOR SELECT
+    TO authenticated
+    USING (user_id = auth.uid());
+
+COMMIT;

--- a/backend/migrations/018_search_query_events.sql
+++ b/backend/migrations/018_search_query_events.sql
@@ -1,0 +1,37 @@
+-- Migration: Create search_query_events table
+-- Purpose: Demand intelligence — capture what users search/filter for when loading
+--          the discover feed. Sellable to realtors as aggregated market demand data.
+-- Date: 2026-04-03
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.search_query_events (
+    event_id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id          uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    session_id       text        NOT NULL,
+    filter_snapshot  jsonb       NOT NULL,
+    results_returned integer     NOT NULL DEFAULT 0 CHECK (results_returned >= 0),
+    "offset"         integer     NOT NULL DEFAULT 0 CHECK ("offset" >= 0),
+    created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_query_events_user_created_at
+    ON public.search_query_events (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_search_query_events_created_at
+    ON public.search_query_events (created_at DESC);
+
+-- GIN index enables queries like: WHERE filter_snapshot @> '{"target_city": "Toronto"}'
+CREATE INDEX IF NOT EXISTS idx_search_query_events_filter_snapshot
+    ON public.search_query_events USING gin (filter_snapshot);
+
+COMMENT ON TABLE public.search_query_events IS
+    'Captures each discover feed load with the active filter state and result count. Pure demand intelligence.';
+
+COMMENT ON COLUMN public.search_query_events.filter_snapshot IS
+    'Full copy of the preference/filter object sent to /api/recommendations.';
+
+COMMENT ON COLUMN public.search_query_events."offset" IS
+    'Pagination offset; 0 means a fresh search, >0 means load-more triggered.';
+
+COMMIT;

--- a/backend/migrations/019_search_query_events_privileges.sql
+++ b/backend/migrations/019_search_query_events_privileges.sql
@@ -1,0 +1,25 @@
+-- Migration: RLS policies for search_query_events
+-- Date: 2026-04-03
+
+BEGIN;
+
+GRANT USAGE ON SCHEMA public TO authenticated, service_role;
+GRANT SELECT, INSERT ON TABLE public.search_query_events TO authenticated, service_role;
+
+ALTER TABLE public.search_query_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "search_query_events_insert_own" ON public.search_query_events;
+CREATE POLICY "search_query_events_insert_own"
+    ON public.search_query_events
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "search_query_events_select_own" ON public.search_query_events;
+CREATE POLICY "search_query_events_select_own"
+    ON public.search_query_events
+    FOR SELECT
+    TO authenticated
+    USING (user_id = auth.uid());
+
+COMMIT;

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -238,4 +238,57 @@ export const api = {
     const data = await response.json();
     return data;
   },
+
+  // ---------------------------------------------------------------------------
+  // Data logging — all four are best-effort. Callers should not await or handle
+  // errors from these; tracking failures must never disrupt UX.
+  // ---------------------------------------------------------------------------
+
+  async postSwipeContext(token, payload) {
+    try {
+      await fetch(`${API_BASE_URL}/api/interactions/swipe-context`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      // Best-effort only.
+    }
+  },
+
+  async postListingView(token, payload) {
+    try {
+      await fetch(`${API_BASE_URL}/api/interactions/listing-views`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      // Best-effort only.
+    }
+  },
+
+  async postPageView(token, payload) {
+    try {
+      await fetch(`${API_BASE_URL}/api/interactions/page-views`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      // Best-effort only.
+    }
+  },
+
+  async postSearchQuery(token, payload) {
+    try {
+      await fetch(`${API_BASE_URL}/api/interactions/search-queries`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      // Best-effort only.
+    }
+  },
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@tanstack/react-query-devtools": "^5.90.2",
         "@vercel/analytics": "^2.0.1",
         "dayjs": "^1.11.18",
+        "i": "^0.3.7",
         "next": "15.5.9",
         "postcss-preset-mantine": "^1.18.0",
         "postcss-simple-vars": "^7.0.1",
@@ -750,6 +751,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.17.8.tgz",
       "integrity": "sha512-42sfdLZSCpsCYmLCjSuntuPcDg3PLbakSmmYfz5Auea8gZYLr+8SS5k647doVu0BRAecqYOytkX2QC5/u/8VHw==",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.26.28",
         "clsx": "^2.1.1",
@@ -795,6 +797,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.8.tgz",
       "integrity": "sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw==",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -1223,6 +1226,7 @@
       "version": "5.90.5",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.5.tgz",
       "integrity": "sha512-pN+8UWpxZkEJ/Rnnj2v2Sxpx1WFlaa9L6a4UO89p6tTQbeo+m0MS8oYDjbggrR8QcTyjKoYWKS3xJQGr3ExT8Q==",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.5"
       },
@@ -1302,6 +1306,7 @@
       "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1370,6 +1375,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -1928,6 +1934,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2493,7 +2500,8 @@
     "node_modules/dayjs": {
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
-      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA=="
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2811,6 +2819,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2985,6 +2994,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3658,6 +3668,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/ignore": {
@@ -4411,6 +4429,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -4736,6 +4755,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -4921,6 +4941,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4929,6 +4950,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5719,6 +5741,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5884,6 +5907,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query-devtools": "^5.90.2",
     "@vercel/analytics": "^2.0.1",
     "dayjs": "^1.11.18",
+    "i": "^0.3.7",
     "next": "15.5.9",
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7.0.1",

--- a/frontend/src/app/components/SwipeCard.jsx
+++ b/frontend/src/app/components/SwipeCard.jsx
@@ -7,7 +7,7 @@ import { ImageWithFallback } from './ImageWithFallback';
 
 const SWIPE_THRESHOLD = 100;
 
-export function SwipeCard({ listing, onSwipe, isTop, stackOffset, onExpand }) {
+export function SwipeCard({ listing, onSwipe, isTop, stackOffset, onExpand, onPhotoChange }) {
   const [dragging, setDragging] = useState(false);
   const [offsetX, setOffsetX] = useState(0);
   const [leaving, setLeaving] = useState(null); // 'left' | 'right' | null
@@ -96,7 +96,10 @@ export function SwipeCard({ listing, onSwipe, isTop, stackOffset, onExpand }) {
     const timer = setInterval(() => {
       setSweeping(true);
       setTimeout(() => {
-        setImageIndex(i => (i + 1) % images.length);
+        setImageIndex(i => {
+          onPhotoChange && onPhotoChange();
+          return (i + 1) % images.length;
+        });
         setSweeping(false);
       }, 300);
     }, 3000);
@@ -194,7 +197,7 @@ export function SwipeCard({ listing, onSwipe, isTop, stackOffset, onExpand }) {
                 zIndex: 30,
               }}
               onMouseDown={(e) => e.stopPropagation()}
-              onClick={(e) => { e.stopPropagation(); setImageIndex(i => Math.max(0, i - 1)); }}
+              onClick={(e) => { e.stopPropagation(); setImageIndex(i => { onPhotoChange && onPhotoChange(); return Math.max(0, i - 1); }); }}
             >
               <IconChevronLeft size={14} />
             </ActionIcon>
@@ -210,7 +213,7 @@ export function SwipeCard({ listing, onSwipe, isTop, stackOffset, onExpand }) {
                 zIndex: 30,
               }}
               onMouseDown={(e) => e.stopPropagation()}
-              onClick={(e) => { e.stopPropagation(); setImageIndex(i => Math.min(images.length - 1, i + 1)); }}
+              onClick={(e) => { e.stopPropagation(); setImageIndex(i => { onPhotoChange && onPhotoChange(); return Math.min(images.length - 1, i + 1); }); }}
             >
               <IconChevronRight size={14} />
             </ActionIcon>

--- a/frontend/src/app/discover/page.jsx
+++ b/frontend/src/app/discover/page.jsx
@@ -41,6 +41,37 @@ function getOrCreateSwipeSessionId() {
   return generated;
 }
 
+function collectDeviceContext() {
+  if (typeof window === 'undefined') return {};
+  const ua = navigator.userAgent || '';
+  const isTablet = /Tablet|iPad/i.test(ua);
+  const isMobile = /Mobi|Android/i.test(ua);
+  const deviceType = isTablet ? 'tablet' : isMobile ? 'mobile' : 'desktop';
+
+  let os = 'unknown';
+  if (/Windows/i.test(ua)) os = 'windows';
+  else if (/Mac OS X/i.test(ua)) os = 'macos';
+  else if (/Android/i.test(ua)) os = 'android';
+  else if (/iPhone|iPad|iPod/i.test(ua)) os = 'ios';
+  else if (/Linux/i.test(ua)) os = 'linux';
+
+  let browser = 'unknown';
+  if (/Firefox\/\d/i.test(ua)) browser = 'firefox';
+  else if (/Edg\/\d/i.test(ua)) browser = 'edge';
+  else if (/Chrome\/\d/i.test(ua) && !/Chromium/i.test(ua)) browser = 'chrome';
+  else if (/Safari\/\d/i.test(ua) && !/Chrome/i.test(ua)) browser = 'safari';
+
+  const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  return {
+    device_type: deviceType,
+    os,
+    browser,
+    screen_width: window.screen?.width ?? null,
+    screen_height: window.screen?.height ?? null,
+    connection_type: conn?.effectiveType ?? conn?.type ?? null,
+  };
+}
+
 // ── page ────────────────────────────────────────────────────────────────────
 
 export default function DiscoverPage() {
@@ -68,6 +99,10 @@ function DiscoverContent() {
   const [hasMore, setHasMore] = useState(false);
   const swipeSessionIdRef = useRef(null);
   const nextOffsetRef = useRef(0);
+  const activeFilterBodyRef = useRef({});
+  const cardViewStartRef = useRef(null);
+  const cardPhotoCountRef = useRef(0);
+  const cardExpandedRef = useRef(false);
 
   const fetchRecommendations = useCallback(async ({ append = false } = {}) => {
     setLoading(true);
@@ -175,6 +210,9 @@ function DiscoverContent() {
         ...likedExtras,
       };
 
+      // Cache the filter body so swipe-context events can reference it.
+      activeFilterBodyRef.current = body;
+
       const res = await fetch(`${API_BASE}/api/recommendations`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -200,6 +238,15 @@ function DiscoverContent() {
 
       setHasMore(Boolean(data.has_more));
       nextOffsetRef.current = (data.offset || 0) + (data.count || 0);
+
+      // Fire search query event — demand intelligence, best-effort.
+      if (authState?.accessToken) {
+        void persistSearchQueryEvent({
+          filterBody: body,
+          resultsCount: (data.recommendations || []).length,
+          searchOffset: body.offset || 0,
+        });
+      }
 
       if (append) {
         setListings((prev) => [...prev, ...fresh]);
@@ -280,6 +327,84 @@ function DiscoverContent() {
     }
   }, [authState?.accessToken, userId]);
 
+  const persistSwipeContextEvent = useCallback(async ({ listing, action }) => {
+    if (!authState?.accessToken || !listing?.listing_id) return;
+    if (!swipeSessionIdRef.current) {
+      swipeSessionIdRef.current = getOrCreateSwipeSessionId();
+    }
+    try {
+      await fetch(`${API_BASE}/api/interactions/swipe-context`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authState.accessToken}` },
+        body: JSON.stringify({
+          listing_id: listing.listing_id,
+          action,
+          session_id: swipeSessionIdRef.current,
+          active_filters_snapshot: activeFilterBodyRef.current || null,
+          device_context: collectDeviceContext(),
+        }),
+      });
+    } catch {
+      // Best-effort only.
+    }
+  }, [authState?.accessToken]);
+
+  const persistListingViewEvent = useCallback(async ({ listing, surface }) => {
+    if (!authState?.accessToken || !listing?.listing_id) return;
+    if (!swipeSessionIdRef.current) {
+      swipeSessionIdRef.current = getOrCreateSwipeSessionId();
+    }
+    const duration_ms =
+      cardViewStartRef.current != null
+        ? Math.max(0, Date.now() - cardViewStartRef.current)
+        : null;
+    try {
+      await fetch(`${API_BASE}/api/interactions/listing-views`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authState.accessToken}` },
+        body: JSON.stringify({
+          listing_id: listing.listing_id,
+          surface,
+          session_id: swipeSessionIdRef.current,
+          view_duration_ms: duration_ms,
+          expanded: cardExpandedRef.current,
+          photos_viewed_count: cardPhotoCountRef.current,
+        }),
+      });
+    } catch {
+      // Best-effort only.
+    }
+  }, [authState?.accessToken]);
+
+  const persistSearchQueryEvent = useCallback(async ({ filterBody, resultsCount, searchOffset }) => {
+    if (!authState?.accessToken) return;
+    if (!swipeSessionIdRef.current) {
+      swipeSessionIdRef.current = getOrCreateSwipeSessionId();
+    }
+    try {
+      await fetch(`${API_BASE}/api/interactions/search-queries`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authState.accessToken}` },
+        body: JSON.stringify({
+          session_id: swipeSessionIdRef.current,
+          filter_snapshot: filterBody,
+          results_returned: resultsCount,
+          offset: searchOffset,
+        }),
+      });
+    } catch {
+      // Best-effort only.
+    }
+  }, [authState?.accessToken]);
+
+  // Reset view-tracking refs whenever the top card changes.
+  useEffect(() => {
+    if (listings.length === 0 || currentIndex >= listings.length) return;
+    cardViewStartRef.current = Date.now();
+    cardPhotoCountRef.current = 0;
+    cardExpandedRef.current = false;
+  }, [currentIndex, listings.length]);
+
   const handleSwipe = useCallback((direction, listing) => {
     const action = direction === 'right' ? 'like' : 'pass';
     if (action === 'like') saveLikedListing(listing);
@@ -291,6 +416,10 @@ function DiscoverContent() {
         ? currentIndex
         : listings.findIndex((item) => item.listing_id === listing?.listing_id);
     const startedAt = typeof performance !== 'undefined' ? performance.now() : null;
+
+    // Fire data logging events before advancing the index (best-effort, parallel).
+    void persistListingViewEvent({ listing, surface: 'discover_card' });
+    void persistSwipeContextEvent({ listing, action });
 
     void persistSwipeEvent({
       listing,
@@ -306,7 +435,7 @@ function DiscoverContent() {
         detail: { direction },
       }));
     }
-  }, [currentIndex, listings, persistSwipeEvent, tourPhase]);
+  }, [currentIndex, listings, persistSwipeEvent, persistListingViewEvent, persistSwipeContextEvent, tourPhase]);
 
   const handleButton = (direction) => {
     if (currentIndex >= listings.length) return;
@@ -320,6 +449,7 @@ function DiscoverContent() {
 
 
   const openExpanded = (listing) => {
+    cardExpandedRef.current = true;
     setExpandedImageIndex(0);
     setExpandedListing(listing);
   };
@@ -481,6 +611,7 @@ function DiscoverContent() {
                       isTop={offset === 0}
                       stackOffset={offset}
                       onExpand={openExpanded}
+                      onPhotoChange={offset === 0 ? () => { cardPhotoCountRef.current += 1; } : undefined}
                     />
                   );
                 })}

--- a/frontend/src/app/hooks/usePageTracking.js
+++ b/frontend/src/app/hooks/usePageTracking.js
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const SESSION_KEY = 'padly_swipe_session_id';
+
+function getSessionId() {
+  if (typeof window === 'undefined') return 'ssr-session';
+  const existing = sessionStorage.getItem(SESSION_KEY);
+  if (existing) return existing;
+  const id =
+    typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  sessionStorage.setItem(SESSION_KEY, id);
+  return id;
+}
+
+/**
+ * Tracks how long an authenticated user spends on a page.
+ *
+ * On mount: records start time.
+ * On unmount: fires POST /api/interactions/page-views with duration_ms via
+ *   keepalive fetch so the request survives component unmount / navigation.
+ *
+ * @param {string} pageName       - Must match the CHECK constraint in page_view_events
+ *                                  (discover | matches | listing_detail | preferences |
+ *                                   account | groups | roommates | onboarding)
+ * @param {string|null} token     - User's JWT access token (from useAuth).
+ *                                  If falsy, no event is fired.
+ * @param {string|null} referrer  - Optional previous page name.
+ */
+export function usePageTracking(pageName, token, referrer = null) {
+  const startRef = useRef(null);
+  const sessionRef = useRef(null);
+
+  useEffect(() => {
+    if (!token) return;
+
+    startRef.current = Date.now();
+    sessionRef.current = getSessionId();
+
+    return () => {
+      const duration_ms =
+        startRef.current != null ? Math.max(0, Date.now() - startRef.current) : null;
+
+      const payload = JSON.stringify({
+        page: pageName,
+        session_id: sessionRef.current,
+        duration_ms,
+        referrer_page: referrer || null,
+      });
+
+      // keepalive: true lets the fetch outlive the component unmount.
+      // We use fetch (not sendBeacon) because sendBeacon can't carry Authorization headers.
+      fetch(`${API_BASE}/api/interactions/page-views`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: payload,
+        keepalive: true,
+      }).catch(() => {
+        // Best-effort only — swallow silently.
+      });
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+}

--- a/frontend/src/app/listings/[id]/page.jsx
+++ b/frontend/src/app/listings/[id]/page.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { Container, Title, Text, Stack, Box, Button, Group, Badge, Grid } from '@mantine/core';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
@@ -7,11 +8,47 @@ import { Navigation } from '../../components/Navigation';
 import { ImageWithFallback } from '../../components/ImageWithFallback';
 import { api } from '../../../../lib/api';
 import { getErrorMessage } from '../../../../lib/errorHandling';
+import { useAuth } from '../../contexts/AuthContext';
+import { usePageTracking } from '../../hooks/usePageTracking';
 import Link from 'next/link';
 
 export default function ListingDetailPage() {
   const params = useParams();
   const listingId = params.id;
+  const { authState } = useAuth();
+
+  usePageTracking('listing_detail', authState?.accessToken);
+
+  // Track view duration for this listing detail page.
+  const viewStartRef = useRef(Date.now());
+  useEffect(() => {
+    if (!authState?.accessToken) return;
+    viewStartRef.current = Date.now();
+    const sessionId =
+      (typeof sessionStorage !== 'undefined' && sessionStorage.getItem('padly_swipe_session_id')) ||
+      `listing-detail-${Date.now()}`;
+
+    return () => {
+      const duration_ms = Math.max(0, Date.now() - viewStartRef.current);
+      fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/interactions/listing-views`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authState.accessToken}`,
+        },
+        body: JSON.stringify({
+          listing_id: listingId,
+          surface: 'listing_detail',
+          session_id: sessionId,
+          view_duration_ms: duration_ms,
+          expanded: false,
+          photos_viewed_count: 0,
+        }),
+        keepalive: true,
+      }).catch(() => {});
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listingId, authState?.accessToken]);
 
   const { data: listingData, isLoading, error, refetch } = useQuery({
     queryKey: ['listing', listingId],

--- a/frontend/src/app/matches/page.jsx
+++ b/frontend/src/app/matches/page.jsx
@@ -10,6 +10,7 @@ import { Navigation } from '../components/Navigation';
 import { ProtectedRoute } from '../components/ProtectedRoute';
 import { ImageWithFallback } from '../components/ImageWithFallback';
 import { useAuth } from '../contexts/AuthContext';
+import { usePageTracking } from '../hooks/usePageTracking';
 import { getLikedListings } from '../discover/likedListings';
 import {
   createAppError,
@@ -30,6 +31,8 @@ function MatchesPageContent() {
   const router = useRouter();
   const { user, authState } = useAuth();
   const userId = user?.profile?.id;
+
+  usePageTracking('matches', authState?.accessToken);
 
   const [listings, setListings] = useState([]);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
● ## Data Logging Infrastructure — MVP Analytics Layer

  ### Overview
  Adds comprehensive behavioral data collection across the platform. Zero changes to existing tables — all new, purely additive. Designed for two purposes:
  1. **AI model training** — richer signals for the matching algorithm feedback loop
  2. **Data monetization** — aggregated demand intelligence sellable to realtors and housing platforms

  ---

  ### New Tables (4)

  | Table | Purpose |
  |---|---|
  | `swipe_context_events` | Companion to `swipe_interactions`. Captures the active filter state and device/browser context at the time of each swipe. Join on `(actor_user_id, listing_id, session_id)`. |
  | `listing_view_events` | How long a user looked at a listing before acting, whether they expanded it, and how many photos they scrolled through. Tracked on the discover card and listing detail page. |
  | `page_view_events` | Page-level funnel analytics — which pages users visit and time spent on each. Reveals drop-off points in the signup → preferences → discover → match funnel. |
  | `search_query_events` | Full filter snapshot + result count captured every time the discover feed loads. Pure demand intelligence — what users are searching for vs. what inventory exists. |

  All tables have RLS enabled. Users can only read/write their own rows.

  ---

  ### New Backend Endpoints

  All endpoints live under `/api/interactions/` and follow the existing best-effort pattern — failures return a 500 but never disrupt the user.

  - `POST /api/interactions/swipe-context`
  - `POST /api/interactions/listing-views`
  - `POST /api/interactions/page-views`
  - `POST /api/interactions/search-queries`

  ---

  ### Frontend Instrumentation

  - **Discover page** — fires `swipe-context` (with filter snapshot + device info) and `listing-views` (with view duration) alongside every swipe. Fires `search-queries` on every feed load.
  - **SwipeCard** — exposes `onPhotoChange` callback so the parent can count photo advances without the card needing to call any API itself.
  - **Listing detail page** — tracks time spent via `useEffect` unmount, fires `listing-views` with `keepalive: true`.
  - **Matches page** — page view tracking via the new `usePageTracking` hook.
  - **`usePageTracking` hook** — reusable hook added at `hooks/usePageTracking.js`. Drop it into any page with a token to get automatic page view tracking.

  ---

  ### What This Enables

  - **For the model** — view duration, filter context, and photo engagement are strong signals that go beyond binary like/pass. A user who stares at a listing for 30s before passing tells a different story than  
  one who passes in 2s.
  - **For realtors** — `search_query_events` with its GIN-indexed `filter_snapshot` JSONB column enables queries like *"how many users searched for dog-friendly 2-beds under $2000 in Toronto this month with zero 
  results?"* — unmet demand data.
  - **Session correlation** — all 4 tables share the same `session_id` from `sessionStorage`, so a user's full journey within a session is correlatable across tables with a single join.

  ---

  ### Migrations
  `012` through `019` — even numbers create tables, odd numbers set RLS policies. Safe to run in any environment; all use `CREATE TABLE IF NOT EXISTS`.