### PR TITLE
Fix stale recommendations when location preferences change

### DIFF
--- a/frontend/src/app/components/PreferencesForm.jsx
+++ b/frontend/src/app/components/PreferencesForm.jsx
@@ -299,7 +299,9 @@ export function PreferencesForm() {
       setSuccess(true);
       setTimeout(() => setSuccess(false), 3000);
       queryClient.invalidateQueries({ queryKey: ['preferences', userId] });
+      queryClient.invalidateQueries({ queryKey: ['user-prefs', userId] });
       queryClient.invalidateQueries({ queryKey: ['discover-feed', userId] });
+      window.scrollTo({ top: 0, behavior: 'smooth' });
 
       if (tourPhase === 'preferences') {
         window.dispatchEvent(new CustomEvent('padly-tour-prefs-saved'));

--- a/frontend/src/app/discover/page.jsx
+++ b/frontend/src/app/discover/page.jsx
@@ -156,6 +156,25 @@ function DiscoverContent() {
   const { tourPhase } = usePadlyTour();
   const userId = user?.profile?.id;
   const router = useRouter();
+
+  // Lightweight prefs fetch — only used to key the feed query on city so
+  // changing location always triggers a fresh fetch.
+  const { data: prefsData } = useQuery({
+    queryKey: ['user-prefs', userId],
+    queryFn: async () => {
+      const token = await getValidToken();
+      if (!token) return null;
+      const res = await fetch(`${API_BASE}/api/preferences/${userId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) return null;
+      const d = await res.json();
+      return d.data || d || null;
+    },
+    enabled: !!userId,
+    staleTime: 0,
+  });
+  const prefCity = prefsData?.target_city ?? null;
   usePageTracking('discover', authState?.accessToken);
 
   const [listings, setListings] = useState([]);
@@ -481,10 +500,10 @@ function DiscoverContent() {
     error: feedQueryError,
     refetch: refetchFeed,
   } = useQuery({
-    queryKey: ['discover-feed', userId],
+    queryKey: ['discover-feed', userId, prefCity],
     queryFn: () => fetchFeedPage({ offset: 0 }),
-    enabled: !!userId,
-    staleTime: 5 * 60 * 1000,
+    enabled: !!userId && prefCity !== null,
+    staleTime: 0,
     gcTime:    10 * 60 * 1000,
     retry: false,
   });
@@ -494,6 +513,12 @@ function DiscoverContent() {
 
     const restored = loadDiscoverProgress(userId);
     if (!restored) return;
+
+    // If the user changed their city since this progress was saved, discard it.
+    if (prefCity && restored.targetCity && restored.targetCity !== prefCity) {
+      clearDiscoverProgress(userId);
+      return;
+    }
 
     restoredProgressRef.current = true;
     setListings(Array.isArray(restored.listings) ? restored.listings : []);
@@ -597,6 +622,7 @@ function DiscoverContent() {
       missingCorePreferences,
       emptyResultReason,
       rankingContext,
+      targetCity: prefCity,
     });
   }, [
     currentIndex,


### PR DESCRIPTION
  - Key discover-feed query on target_city so changing location triggers a fresh fetch
  - Set staleTime to 0 so recommendations always refetch on navigation
  - Stamp target_city on sessionStorage progress and clear it when city changes
  - Invalidate user-prefs query on save so prefCity updates immediately
  - Scroll to top on preferences save so confirmation is visible
Closes #42 and #40 