### PR TITLE
Redirect non-admin users from admin page

### DIFF
--- a/frontend/src/app/admin/evaluation/page.jsx
+++ b/frontend/src/app/admin/evaluation/page.jsx
@@ -26,6 +26,7 @@ import {
   IconRefresh,
   IconShieldLock,
 } from '@tabler/icons-react';
+import { useRouter } from 'next/navigation';
 import { Navigation } from '../../components/Navigation';
 import { ProtectedRoute } from '../../components/ProtectedRoute';
 import { useAuth } from '../../contexts/AuthContext';
@@ -224,6 +225,21 @@ export default function AdminEvaluationPage() {
 function AdminEvaluationPageContent() {
   const { user, isLoading, getValidToken } = useAuth();
   const isAdmin = user?.profile?.role === 'admin';
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isAdmin) {
+      router.replace('/');
+    }
+  }, [isLoading, isAdmin, router]);
+
+  if (isLoading || !isAdmin) {
+    return (
+      <Center style={{ minHeight: '100vh' }}>
+        <Loader size="lg" />
+      </Center>
+    );
+  }
   const [days, setDays] = useState('30');
   const [surface, setSurface] = useState('matches');
   const [variant, setVariant] = useState('all');


### PR DESCRIPTION
## Summary

- Non-admin users navigating to `/admin/evaluation` are now redirected to `/` instead of seeing the page with a "restricted" warning
- Shows a loader while the role check completes, then redirects if `user.profile.role !== 'admin'`

## Test plan

- [ ] Log in as a non-admin user, navigate to `/admin/evaluation` — should redirect to `/`
- [ ] Log in as an admin user — admin page should load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)